### PR TITLE
Small agreement mistake, my bad

### DIFF
--- a/src/main/resources/assets/mo_glass/lang/fr_fr.json
+++ b/src/main/resources/assets/mo_glass/lang/fr_fr.json
@@ -1,6 +1,6 @@
 {
   "block.mo_glass.glass_slab": "Dalle de verre",
-  "block.mo_glass.tinted_glass_slab": "Dalle de verre teintée",
+  "block.mo_glass.tinted_glass_slab": "Dalle de verre teinté",
   "block.mo_glass.white_stained_glass_slab": "Dalle de verre blanc",
   "block.mo_glass.orange_stained_glass_slab": "Dalle de verre orange",
   "block.mo_glass.magenta_stained_glass_slab": "Dalle de verre magenta",


### PR DESCRIPTION
"teinté" should be in agreement with "verre" (glass), not with "dalle" (slab), thus no supplementary "e" at the end