### PR TITLE
Use translucent render layer if Translucent Glass mod is present

### DIFF
--- a/src/main/java/net/wurstclient/glass/MoGlassBlocks.java
+++ b/src/main/java/net/wurstclient/glass/MoGlassBlocks.java
@@ -9,6 +9,7 @@ package net.wurstclient.glass;
 
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -139,8 +140,15 @@ public enum MoGlassBlocks
 	
 	public static void initialize()
 	{
-		registerBlockCutoutMipped(GLASS_SLAB, "glass_slab");
-		registerBlockCutoutMipped(GLASS_STAIRS, "glass_stairs");
+		if(FabricLoader.getInstance().isModLoaded("translucent-glass"))
+		{
+			registerBlockTranslucent(GLASS_SLAB, "glass_slab");
+			registerBlockTranslucent(GLASS_STAIRS, "glass_stairs");
+		}else
+		{
+			registerBlockCutoutMipped(GLASS_SLAB, "glass_slab");
+			registerBlockCutoutMipped(GLASS_STAIRS, "glass_stairs");
+		}
 		
 		registerBlockTranslucent(TINTED_GLASS_SLAB, "tinted_glass_slab");
 		registerBlockTranslucent(TINTED_GLASS_STAIRS, "tinted_glass_stairs");


### PR DESCRIPTION
Hi, I'm the developer of the [Translucent Glass](https://modrinth.com/mod/translucent-glass) mod. Since someone was requesting compatibility between our mods, I figured the easiest way to do this would be setting the desired render layer in this mod, during block initialization (translucent if Translucent Glass is present, cutout if it is not). Then, in Translucent Glass, I can add the required texture pack support for Mo Glass blocks.

(Side note: the `else` statement is formatted somewhat weirdly, but Gradle was forcing this style. Is this intentional? I noticed there are no other else statements in the rest of the codebase.)